### PR TITLE
Add single mp4 to wmv converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ A simple Tkinter-based GUI application to convert video files to WMV format.
    supported videos in the directory (and its subdirectories) will be converted
    to `.wmv` files using ffmpeg.
 
+If you want to convert a single MP4 file instead, run `convert_mp4_to_wmv.py`:
+
+```bash
+python convert_mp4_to_wmv.py
+```
+Select an `mp4` file and the script will create a `.wmv` version in the same
+folder.
+
 Supported input extensions include `mp4`, `avi`, `mkv`, `mov`, `flv`, `webm`,
 `mpg`, and `mpeg`.
 

--- a/convert_mp4_to_wmv.py
+++ b/convert_mp4_to_wmv.py
@@ -1,0 +1,52 @@
+import os
+import subprocess
+import tkinter as tk
+from tkinter import filedialog, messagebox
+
+
+def select_file():
+    path = filedialog.askopenfilename(
+        filetypes=[('MP4 files', '*.mp4')])
+    if path:
+        file_var.set(path)
+
+
+def convert_video():
+    src = file_var.get()
+    if not src:
+        messagebox.showerror('Error', 'Please select an MP4 file')
+        return
+
+    dst = os.path.splitext(src)[0] + '.wmv'
+    cmd = ['ffmpeg', '-i', src, dst]
+    result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if result.returncode == 0:
+        messagebox.showinfo('Done', f'Created {dst}')
+    else:
+        messagebox.showerror('Error', f'Failed to convert {src}\n{result.stderr.decode()}')
+
+
+def build_gui():
+    root = tk.Tk()
+    root.title('MP4 to WMV Converter')
+
+    frame = tk.Frame(root, padx=10, pady=10)
+    frame.pack(fill=tk.BOTH, expand=True)
+
+    tk.Label(frame, text='MP4 File:').grid(row=0, column=0, sticky=tk.W)
+    entry = tk.Entry(frame, textvariable=file_var, width=40)
+    entry.grid(row=0, column=1, padx=5)
+    tk.Button(frame, text='Browse', command=select_file).grid(row=0, column=2)
+
+    tk.Button(frame, text='Convert', command=convert_video).grid(row=1, column=1, pady=10)
+
+    root.mainloop()
+
+
+def main():
+    build_gui()
+
+
+if __name__ == '__main__':
+    file_var = tk.StringVar()
+    main()


### PR DESCRIPTION
## Summary
- provide `convert_mp4_to_wmv.py` to convert one mp4 file to wmv in the same folder
- document how to use the new script in the README

## Testing
- `python -m py_compile convert_mp4_to_wmv.py`
- `python -m py_compile convert_to_wmv.py`


------
https://chatgpt.com/codex/tasks/task_e_68880c5ad258832fb2a3de475a0bd7b5